### PR TITLE
fix: プロップ配置の際、カーソルの位置とプレビューの位置が一致しない問題を修正 (#10)

### DIFF
--- a/Assets/Scripts/Systems/GridSystem.cs
+++ b/Assets/Scripts/Systems/GridSystem.cs
@@ -297,8 +297,10 @@ namespace DominantK.Systems
 
         public GridCell GetCellFromWorldPosition(Vector3 worldPos)
         {
-            int x = Mathf.FloorToInt(worldPos.x / cellSize);
-            int z = Mathf.FloorToInt(worldPos.z / cellSize);
+            // NOTE: GetWorldPositionはセルの中心座標を返すため、
+            // ワールド座標からセル座標への変換時もセル中心を基準にする
+            int x = Mathf.RoundToInt(worldPos.x / cellSize - 0.5f);
+            int z = Mathf.RoundToInt(worldPos.z / cellSize - 0.5f);
             return GetCell(x, z);
         }
 


### PR DESCRIPTION
## 概要
プロップ配置時にカーソル位置とプレビュー位置がずれていた問題を修正しました。

## 関連Issue
Closes #10

## 原因
`GridSystem.GetCellFromWorldPosition`でワールド座標からセル座標への変換時に、セル中心のオフセット（`cellSize / 2f`）が考慮されていませんでした。

`GetWorldPosition`はセルの中心座標を返しますが、`GetCellFromWorldPosition`は単純に`FloorToInt`で切り捨てていたため、変換の対称性がありませんでした。

## 変更点
- `GridSystem.GetCellFromWorldPosition`の座標変換ロジックを修正
  - `FloorToInt`から`RoundToInt`に変更し、セル中心を基準とした変換に修正

## テスト確認項目
- [ ] プロップ選択後、マウスカーソルの位置とプレビューの位置が一致することを確認
- [ ] 配置時に意図したセルに配置されることを確認

---
Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* グリッドシステムの座標変換ロジックを最適化しました。ワールド座標からグリッドセルへのマッピング精度が向上し、より正確でセンター寄せされたセル割り当てが実現します。ゲーム内オブジェクトのグリッド配置の認識精度が改善されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->