### PR TITLE
update: Cinemachine を 3.1.2 に更新 (Unity 6.3対応)

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.unity.addressables": "2.7.4",
     "com.unity.ai.navigation": "2.0.9",
-    "com.unity.cinemachine": "2.10.5",
+    "com.unity.cinemachine": "3.1.2",
     "com.unity.collab-proxy": "2.10.2",
     "com.unity.entities": "1.4.2",
     "com.unity.entities.graphics": "1.4.15",


### PR DESCRIPTION
## Summary
- Cinemachine パッケージを 2.10.5 から 3.1.2 に更新
- Unity 6.3 では Cinemachine 3.x 系列が推奨されるため

Closes #6

## 変更内容
- `Packages/manifest.json` の `com.unity.cinemachine` を `3.1.2` に変更

## Test plan
- [ ] Unity エディタでプロジェクトが正常に開けることを確認
- [ ] Cinemachine 関連の機能が動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cinemachineカメラシステムの依存関係をバージョン2.10.5からバージョン3.1.2に更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->